### PR TITLE
Persists notifications on persister and adds an endpoint to retrieve them on history

### DIFF
--- a/docs/history.apib
+++ b/docs/history.apib
@@ -222,3 +222,39 @@ Gets the raw data stored by the STH since certain date backwards (or the current
                     }
                 ]
 }
+
+
+## Retrieving notifications [/notifications/history?{field}={value}]
+
++ Parameters
+    + field: subject (optional, string) - Wich field of the notifications will be filtered. If the field is in the metaAttrsFilter key, just pass the key itself.
+    + value: "debug" (optional, string) - Value that will be compared in the filter. If the value type is a string, pass it as "value", if it is int, pass it normally.
+
+### Get notifications from a tenant [GET]
++ Request (application/json)
+
+    + header
+
+            Authorization: Bearer JWT
+
++ Response 200 (application/json; charset=UTF-8)
+
+    + body
+
+            {
+                "notifications": [
+                    {
+                        "msgID": "12345",
+                        "metaAttrsFilter": {
+                        "level": 3,
+                        "shouldPersist": true
+                    },
+                    "message": "DEU ALGUMA COISA MUITO ERRADO",
+                    "subject": "debug",
+                    "ts": "2019-02-20T17:17:52.863000Z"
+                    }
+                ]
+}
+
+
+            

--- a/docs/history.apib
+++ b/docs/history.apib
@@ -66,7 +66,7 @@ This path will retrieve all data from all device's attributes, unless a paramete
 
               {
                 "protocol": [],
-                "temperature": 
+                "temperature":
                 [
                     {
                         "device_id": "labtemp",
@@ -107,7 +107,7 @@ This path will retrieve all data from all device's attributes, unless a paramete
                 ]
               }
 
-            
+
 
 ## Filtering by offset and limit [/STH/v1/contextEntities/type/{device_type}/id/{device_id}/attributes/{attr}?hLimit={hLimit}&dateFrom={dateFrom}&dateTo={dateTo}]
 Gets the raw data stored by the STH from certain date onwards (or the origin of time if no starting date is provided) applying certain offset and a limit to the number of entries to be retrieved. Makes it possible to paginate over the stored raw data.
@@ -227,7 +227,7 @@ Gets the raw data stored by the STH since certain date backwards (or the current
 ## Retrieving notifications [/notifications/history?{field}={value}]
 
 + Parameters
-    + field: subject (optional, string) - Wich field of the notifications will be filtered. If the field is in the metaAttrsFilter key, just pass the key itself.
+    + field: subject (optional, string) - Which field of the notifications will be filtered. If the field is in the metaAttrsFilter key, just pass the key itself.
     + value: "debug" (optional, string) - Value that will be compared in the filter. If the value type is a string, pass it as "value", if it is int, pass it normally.
 
 ### Get notifications from a tenant [GET]
@@ -249,7 +249,7 @@ Gets the raw data stored by the STH since certain date backwards (or the current
                         "level": 3,
                         "shouldPersist": true
                     },
-                    "message": "DEU ALGUMA COISA MUITO ERRADO",
+                    "message": "Something went wrong.",
                     "subject": "debug",
                     "ts": "2019-02-20T17:17:52.863000Z"
                     }
@@ -257,4 +257,3 @@ Gets the raw data stored by the STH since certain date backwards (or the current
 }
 
 
-            

--- a/history/api/models.py
+++ b/history/api/models.py
@@ -203,23 +203,18 @@ class NotificationHistory(object):
 
     @staticmethod
     def get_query(filter):
+        logger.info(f"filter: {filter}")
         query = {}
 
         if(len(filter)):
             for field in filter.keys():
-                value = filter[field][1]
-                condition = filter[field][0]
+                value = filter[field][0]
 
                 if(field != "subject"):
                     value = int(value)
                     field = "metaAttrsFilter." + field
 
-                query[field] = {}
-
-                if(condition != 'eq'):
-                    query[field]['$' + condition] = value
-                else:
-                    query[field] = value 
+                query[field] = value 
 
         sort = [('ts', pymongo.DESCENDING)]
         ls_filter = {"_id" : False, '@timestamp': False, '@version': False}

--- a/history/api/models.py
+++ b/history/api/models.py
@@ -79,11 +79,11 @@ class HistoryUtil(object):
         return HistoryUtil.db['device_history']
 
     @staticmethod
-    def get_collection(service, device_id):
+    def get_collection(service, item):
         db = HistoryUtil.get_db()
-        collection_name = "%s_%s" % (service, device_id)
+        collection_name = "%s_%s" % (service, item)
         if collection_name in db.collection_names():
-            return db["%s_%s" % (service, device_id)]
+            return db["%s_%s" % (service, item)]
         else:
             raise falcon.HTTPNotFound(title="Device not found",
                                       description="No data for the given device could be found")
@@ -180,6 +180,19 @@ class DeviceHistory(object):
 
         resp.status = falcon.HTTP_200
         resp.body = json.dumps(history)
+
+class NotificationHistory(object):
+
+    @staticmethod
+    def on_get(req, resp):
+        logger.info(f"req is: {req}")
+        collection = HistoryUtil.get_collection(req.context['related_service'], "notifications")
+        
+        if req.params.keys():
+            logger.info("Will filter notifications")
+            
+
+
 
 class STHHistory(object):
     """ Deprecated: implements STH's NGSI-like historical view of data """

--- a/history/api/models.py
+++ b/history/api/models.py
@@ -97,10 +97,10 @@ class HistoryUtil(object):
         return "int"
 
     @staticmethod
-    def model_value(value, type):
-        if(type == "int"):
+    def model_value(value, type_arg):
+        if(type_arg == "int"):
             return int(value)
-        elif(type == "string"):
+        elif(type_arg == "string"):
             ret = ""
             for l in value:
                 if l != '"':
@@ -210,10 +210,10 @@ class NotificationHistory(object):
         collection = HistoryUtil.get_collection(req.context['related_service'], "notifications")
         history = {}
         logger.info("Will retrieve notifications")
-        filter = req.params
-        query = NotificationHistory.get_query(filter)      
+        filter_query = req.params
+        query = NotificationHistory.get_query(filter_query)      
         history['notifications'] = NotificationHistory.get_notifications(collection, query)
-        if(not len(history['notifications'])):
+        if(not history['notifications']):
             msg = "There aren't notifications for this tenant on this filter"
             raise falcon.HTTPNotFound(title="Notifications not found", description=msg)
 
@@ -221,11 +221,11 @@ class NotificationHistory(object):
         resp.body = json.dumps(history)
 
     @staticmethod
-    def get_query(filter):
+    def get_query(filter_query):
         query = {}
-        if(len(filter)):
-            for field in filter.keys():
-                value = filter[field]
+        if(filter_query):
+            for field in filter_query.keys():
+                value = filter_query[field]
 
                 if(field != "subject"):
                     field = "metaAttrsFilter." + field

--- a/history/api/models.py
+++ b/history/api/models.py
@@ -203,12 +203,11 @@ class NotificationHistory(object):
 
     @staticmethod
     def get_query(filter):
-        logger.info(f"filter: {filter}")
         query = {}
 
         if(len(filter)):
             for field in filter.keys():
-                value = filter[field][0]
+                value = filter[field]
 
                 if(field != "subject"):
                     value = int(value)

--- a/history/app.py
+++ b/history/app.py
@@ -9,11 +9,12 @@ import falcon
 
 # Local imports
 from history import conf
-from history.api.models import DeviceHistory, STHHistory, AuthMiddleware
+from history.api.models import DeviceHistory, STHHistory, AuthMiddleware, NotificationHistory
 
 # Create falcon app
 app = falcon.API(middleware=[AuthMiddleware()])
 app.add_route('/device/{device_id}/history', DeviceHistory())
+app.add_route('/notifications/history', NotificationHistory())
 app.add_route('/STH/v1/contextEntities/type/{device_type}/id/{device_id}/attributes/{attr}', STHHistory())
 
 # Useful for debugging problems in API, it works with pdb

--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -42,12 +42,12 @@ class Persister:
         """
         self.db[collection_name].create_index([('ts', pymongo.DESCENDING)])
         self.db[collection_name].create_index('ts', expireAfterSeconds=conf.db_expiration)
-    
+
     def create_indexes_for_notifications(self, tenants):
         LOGGER.debug(f"Creating indexes for tenants: {tenants}")
         for tenant in tenants:
             self.create_index_for_tenant(tenant)
-    
+
     def create_index_for_tenant(self, tenant):
         collection_name = "{}_{}".format(tenant, "notifications")
         self.create_indexes(collection_name)
@@ -189,6 +189,7 @@ class Persister:
             LOGGER.debug(f"Received a notification: {notification}. Will check if it will be persisted.")
         except Exception as error:
             LOGGER.debug(f"Invalid JSON: {error}")
+            return
         notification['ts'] = self.parse_datetime(notification.get("timestamp"))
         del notification['timestamp']
         if('shouldPersist' in notification['metaAttrsFilter']):

--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -191,15 +191,18 @@ class Persister:
             LOGGER.debug(f"Invalid JSON: {error}")
         notification['ts'] = self.parse_datetime(notification.get("timestamp"))
         del notification['timestamp']
-        if(notification['metaAttrsFilter']['shouldPersist']):
-            LOGGER.debug("Notification should be persisted.")
-            try:
-                collection_name = "{}_{}".format(tenant,"notifications")
-                self.db[collection_name].insert_one(notification)
-            except Exception as error:
-                LOGGER.debug(f"Failed to persist notification:\n{error}")
-        else:
+        if('shouldPersist' in notification['metaAttrsFilter']):
+            if(notification['metaAttrsFilter']['shouldPersist']):
+                LOGGER.debug("Notification should be persisted.")
+                try:
+                    collection_name = "{}_{}".format(tenant,"notifications")
+                    self.db[collection_name].insert_one(notification)
+                except Exception as error:
+                    LOGGER.debug(f"Failed to persist notification:\n{error}")
+            else:
                 LOGGER.debug(f"Notification should not be persisted. Discarding it.")
+        else:
+            LOGGER.debug(f"Notification should not be persisted. Discarding it.")
 
 
 

--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -5,7 +5,7 @@ import pymongo
 from datetime import datetime
 from dateutil.parser import parse
 from history import conf
-from dojot.module import Messenger, Config
+from dojot.module import Messenger, Config, Auth
 from dojot.module.logger import Log
 
 LOGGER = Log().color_log()
@@ -42,6 +42,16 @@ class Persister:
         """
         self.db[collection_name].create_index([('ts', pymongo.DESCENDING)])
         self.db[collection_name].create_index('ts', expireAfterSeconds=conf.db_expiration)
+    
+    def create_indexes_for_notifications(self, tenants):
+        LOGGER.debug(f"Creating indexes for tenants: {tenants}")
+        for tenant in tenants:
+            self.create_index_for_tenant(tenant)
+    
+    def create_index_for_tenant(self, tenant):
+        collection_name = "{}_{}".format(tenant, "notifications")
+        self.create_indexes(collection_name)
+
 
     def enable_collection_sharding(self, collection_name):
         """
@@ -167,6 +177,31 @@ class Persister:
             new_message = self.parse_message(data)
             self.handle_event_data(tenant, new_message)
 
+    def handle_new_tenant(self, tenant, message):
+        data = json.loads(message)
+        new_tenant = data['tenant']
+        LOGGER.debug(f"Received a new tenant: {new_tenant}. Will create index for it.")
+        self.create_index_for_tenant(new_tenant)
+
+    def handle_notification(self, tenant, message):
+        try:
+            notification = json.loads(message)
+            LOGGER.debug(f"Received a notification: {notification}. Will check if it will be persisted.")
+        except Exception as error:
+            LOGGER.debug(f"Invalid JSON: {error}")
+        notification['ts'] = self.parse_datetime(notification.get("timestamp"))
+        del notification['timestamp']
+        if(notification['metaAttrsFilter']['shouldPersist']):
+            LOGGER.debug("Notification should be persisted.")
+            try:
+                collection_name = "{}_{}".format(tenant,"notifications")
+                self.db[collection_name].insert_one(notification)
+            except Exception as error:
+                LOGGER.debug(f"Failed to persist notification:\n{error}")
+        else:
+                LOGGER.debug(f"Notification should not be persisted. Discarding it.")
+
+
 
 def main():
     """
@@ -174,17 +209,24 @@ def main():
     and device-data topics and add callbacks to events related to that subjects
     """
     config = Config()
+    auth = Auth(config)
     LOGGER.debug("Initializing persister...")
     persister = Persister()
     persister.init_mongodb()
+    persister.create_indexes_for_notifications(auth.get_tenants())
     LOGGER.debug("... persister was successfully initialized.")
     LOGGER.debug("Initializing dojot messenger...")
     messenger = Messenger("Persister",config)
     messenger.init()
     messenger.create_channel(config.dojot['subjects']['devices'], "r")
     messenger.create_channel(config.dojot['subjects']['device_data'], "r")
+    # TODO: add notifications to config on dojot-module-python
+    messenger.create_channel("dojot.notifications", "r")
     messenger.on(config.dojot['subjects']['devices'], "message", persister.handle_event_devices)
     messenger.on(config.dojot['subjects']['device_data'], "message", persister.handle_event_data)
+    messenger.on(config.dojot['subjects']['tenancy'], "message", persister.handle_new_tenant)
+    messenger.on("dojot.notifications", "message", persister.handle_notification)
     LOGGER.debug("... dojot messenger was successfully initialized.")
+
 if __name__=="__main__":
     main()

--- a/tests/dredd-hooks/operation_hook.py
+++ b/tests/dredd-hooks/operation_hook.py
@@ -4,7 +4,7 @@ import json
 from history.subscriber.persister import Persister
 
 @hooks.before_each
-def create__device(transaction):
+def setup(transaction):
 
     _create_device = {
         "event": "create",
@@ -38,3 +38,26 @@ def create__device(transaction):
 
     _update_data['attrs']['temperature'] = "23.12"
     persister.handle_event_data("admin", json.dumps(_update_data))
+
+
+    _new_tenant = {
+        "tenant": "admin"
+    }
+
+    persister.handle_new_tenant("admin", json.dumps(_new_tenant))
+
+    _notification = {
+        "msgID": "12345",
+        "timestamp": 1551111524,
+        "metaAttrsFilter": {
+            "level": 1,
+            "shouldPersist": "True"
+        },
+        "message": "DEU ALGUMA COISA MUITO ERRADO",
+        "subject": "debug"
+    }
+    try:
+        persister.handle_notification("admin", json.dumps(_notification))
+        
+    except Exception as error:
+        print("\n\n\n\nAAAAA\n\n\n\n")

--- a/tests/dredd-hooks/operation_hook.py
+++ b/tests/dredd-hooks/operation_hook.py
@@ -56,8 +56,5 @@ def setup(transaction):
         "message": "DEU ALGUMA COISA MUITO ERRADO",
         "subject": "debug"
     }
-    try:
-        persister.handle_notification("admin", json.dumps(_notification))
-        
-    except Exception as error:
-        print("\n\n\n\nAAAAA\n\n\n\n")
+    
+    persister.handle_notification("admin", json.dumps(_notification))

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,3 +1,3 @@
-dredd_hooks==0.1.3
+dredd_hooks>=0.2.0
 PyJWT==1.5.3
 Flask==1.0.2


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Feature.


* **What is the current behavior?** (You can also link to an open issue here)
Nowadays, persister doesn't persists notifications and history doesn't have an endpoint to check the notification history.


* **What is the new behavior (if this is a feature change)?**
This PR adds and endpoint on history to retrieve notifications and changes persister to save those notifications received.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is connected to dojot/dojot#930
This is connected to dojot/dojot#952

* **Other information**:
