### PR TITLE
Changed to not run services as PID 1

### DIFF
--- a/docker/history.docker
+++ b/docker/history.docker
@@ -15,6 +15,8 @@ ADD . /usr/src/app
 RUN ["python", "setup.py", "develop"]
 
 FROM python:3.6-alpine
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]
 
 COPY --from=basis /usr/src/venv /usr/src/venv
 COPY --from=basis /usr/src/app /usr/src/app

--- a/docker/persister.docker
+++ b/docker/persister.docker
@@ -15,6 +15,8 @@ ADD . /usr/src/app
 RUN ["python", "setup.py", "develop"]
 
 FROM python:3.6-alpine
+RUN apk add --no-cache tini
+ENTRYPOINT ["/sbin/tini", "--"]
 
 COPY --from=basis /usr/src/venv /usr/src/venv
 COPY --from=basis /usr/src/app /usr/src/app


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
The services 'persister' and 'history' are running as PID 1.


* **What is the new behavior (if this is a feature change)?**
Tini, which is a 'init' service for docker containers is running as PID 1.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No.

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
No.

* **Other information**:
