### PR TITLE
fix: avoiding non-dict attrs when receiving message

### DIFF
--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -127,22 +127,25 @@ class Persister:
         if metadata.get('tenant', None) != None:
             del metadata['tenant']
         docs = []
-        for attr in data.get('attrs', {}).keys():
-            docs.append({
-                'attr': attr,
-                'value': data['attrs'][attr],
-                'device_id': device_id,
-                'ts': timestamp,
-                'metadata': metadata
-            })
-        if docs:
-            try:
-                collection_name = "{}_{}".format(tenant,device_id)
-                self.db[collection_name].insert_many(docs)
-            except Exception as error:
-                LOGGER.warn('Failed to persist received information.\n%s', error)
+        if type(data["attrs"]) is dict:
+            for attr in data.get('attrs', {}).keys():
+                docs.append({
+                    'attr': attr,
+                    'value': data['attrs'][attr],
+                    'device_id': device_id,
+                    'ts': timestamp,
+                    'metadata': metadata
+                })
+            if docs:
+                try:
+                    collection_name = "{}_{}".format(tenant,device_id)
+                    self.db[collection_name].insert_many(docs)
+                except Exception as error:
+                    LOGGER.warn('Failed to persist received information.\n%s', error)
         else:
-            LOGGER.info('Got empty event from device [%s] - ignoring', device_id)
+            LOGGER.warning(f"Expected attribute dictionary, got {type(data.attr)}")
+            LOGGER.warning("Bailing out")
+
 
     def handle_event_devices(self, tenant, message):
         """


### PR DESCRIPTION
This commit will skip all messages with an "attrs" attribute
that is not a dictionary.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)
Bugfix


* **What is the current behavior?** (You can also link to an open issue here)
If a message contains an 'attr' attribute which does not contain a object, Persister will reboot forever.


* **What is the new behavior (if this is a feature change)?**
This PR checks whether the content type is a dictionary.


* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)
No

* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)
This is connected to dojot/dojot#893

* **Other information**:
