### PR TITLE
behavior modification history and persister

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ DATA_BROKER_URL             |Data Broker address                                
 DEVICE_MANAGER_URL          |Device Manager address                                        |"http://device-manager:5000"
 LOG_LEVEL                   |Define minimum logging level                                  |"INFO"
 PERSISTER_PORT              |Port to be used by persister sevice's endpoints               |8057
+DOJOT_PERSIST_NOTIFICATIONS_ONLY                   |If 'True' only the notification events are persisted, otherwise if 'False' the notification and device events are persisted.                                         |False
 
 ##### Kafka related configuration
 
@@ -209,7 +210,7 @@ DOJOT_SUBJECT_DEVICE_DATA   |Global subject to use when receiving data from devi
 KAFKA_ADDRESS               |Kafta address                                                 |"kafka"
 KAFKA_PORT                  |Kafka port                                                    |9092
 KAFKA_GROUP_ID              |Group ID used when creating consumers                         |"history"
-DOJOT_PERSIST_NOTIFICATIONS_ONLY                   |If 'True' only the notification events are persisted, otherwise if 'False' the notification and device events are persisted.                                         |False
+
 
 ##### MongoDB related configuration
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ HISTORY_DB_ADDRESS          |History database's address                         
 HISTORY_DB_PORT             |History database's port                                       |27017
 HISTORY_DB_REPLICA_SET      |History database's replica set address                        |None
 LOG_LEVEL                   | Sets the log level                                           | "INFO"
-
+DOJOT_PERSIST_NOTIFICATIONS_ONLY                   |Defines a value to change the behavior of the service                                           |False
 ********************************************************************************
 
 ## **How to install History service**
@@ -210,6 +210,7 @@ DOJOT_SUBJECT_DEVICE_DATA   |Global subject to use when receiving data from devi
 KAFKA_ADDRESS               |Kafta address                                                 |"kafka"
 KAFKA_PORT                  |Kafka port                                                    |9092
 KAFKA_GROUP_ID              |Group ID used when creating consumers                         |"history"
+DOJOT_PERSIST_NOTIFICATIONS_ONLY                   |Defines a value to change the behavior of the service                                           |False
 
 ##### MongoDB related configuration
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ HISTORY_DB_ADDRESS          |History database's address                         
 HISTORY_DB_PORT             |History database's port                                       |27017
 HISTORY_DB_REPLICA_SET      |History database's replica set address                        |None
 LOG_LEVEL                   | Sets the log level                                           | "INFO"
-DOJOT_PERSIST_NOTIFICATIONS_ONLY                   |Defines a value to change the behavior of the service                                           |False
+DOJOT_PERSIST_NOTIFICATIONS_ONLY                   |Set a value to change the behavior of the service: example if the value is 'True', only the notification will be persisted and if it is 'false', all services will be working.                                           |False
 ********************************************************************************
 
 ## **How to install History service**
@@ -210,7 +210,7 @@ DOJOT_SUBJECT_DEVICE_DATA   |Global subject to use when receiving data from devi
 KAFKA_ADDRESS               |Kafta address                                                 |"kafka"
 KAFKA_PORT                  |Kafka port                                                    |9092
 KAFKA_GROUP_ID              |Group ID used when creating consumers                         |"history"
-DOJOT_PERSIST_NOTIFICATIONS_ONLY                   |Defines a value to change the behavior of the service                                           |False
+DOJOT_PERSIST_NOTIFICATIONS_ONLY                   |Set a value to change the behavior of the service: example if the value is 'True', only the notification will be persisted and if it is 'false', all services will be working.                                         |False
 
 ##### MongoDB related configuration
 

--- a/README.md
+++ b/README.md
@@ -71,7 +71,6 @@ HISTORY_DB_ADDRESS          |History database's address                         
 HISTORY_DB_PORT             |History database's port                                       |27017
 HISTORY_DB_REPLICA_SET      |History database's replica set address                        |None
 LOG_LEVEL                   | Sets the log level                                           | "INFO"
-DOJOT_PERSIST_NOTIFICATIONS_ONLY                   |Set a value to change the behavior of the service: example if the value is 'True', only the notification will be persisted and if it is 'false', all services will be working.                                           |False
 ********************************************************************************
 
 ## **How to install History service**
@@ -210,7 +209,7 @@ DOJOT_SUBJECT_DEVICE_DATA   |Global subject to use when receiving data from devi
 KAFKA_ADDRESS               |Kafta address                                                 |"kafka"
 KAFKA_PORT                  |Kafka port                                                    |9092
 KAFKA_GROUP_ID              |Group ID used when creating consumers                         |"history"
-DOJOT_PERSIST_NOTIFICATIONS_ONLY                   |Set a value to change the behavior of the service: example if the value is 'True', only the notification will be persisted and if it is 'false', all services will be working.                                         |False
+DOJOT_PERSIST_NOTIFICATIONS_ONLY                   |If 'True' only the notification events are persisted, otherwise if 'False' the notification and device events are persisted.                                         |False
 
 ##### MongoDB related configuration
 

--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ HISTORY_DB_REPLICA_SET      | History database's replica set address            
 HISTORY_DB_DATA_EXPIRATION  | Time (in seconds) that the data must be kept in the database | "604800" (7 days)
 MONGO_SHARD                 |Activate the use of sharding or not                           | False
 
-
 ********************************************************************************
 
 ## **How to install Persister service**

--- a/history/conf.py
+++ b/history/conf.py
@@ -42,7 +42,8 @@ dojot_subject_device_data = os.environ.get(
 dojot_service_management = os.environ.get("DOJOT_SERVICE_MANAGEMENT",
                                           "dojot-management")
 
-dojot_notification_on = os.environ.get("DOJOT_NOTIFICATION_ON", True)
+dojot_persist_notifications_only = os.environ.get("DOJOT_PERSIST_NOTIFICATIONS_ONLY", False)
+
 
 #
 # Other dojot services

--- a/history/conf.py
+++ b/history/conf.py
@@ -42,7 +42,8 @@ dojot_subject_device_data = os.environ.get(
 dojot_service_management = os.environ.get("DOJOT_SERVICE_MANAGEMENT",
                                           "dojot-management")
 
-dojot_persist_notifications_only = os.environ.get("DOJOT_PERSIST_NOTIFICATIONS_ONLY", False)
+dojot_persist_notifications_only = os.environ.get(
+    "DOJOT_PERSIST_NOTIFICATIONS_ONLY", False)
 
 
 #

--- a/history/conf.py
+++ b/history/conf.py
@@ -26,18 +26,23 @@ kafka_host = "" + kafka_address + ":" + str(kafka_port)
 kafka_group_id = os.environ.get('KAFKA_GROUP_ID', "history")
 
 # Global subject to use when publishing tenancy lifecycle events
-dojot_subject_tenancy = os.environ.get("DOJOT_SUBJECT_TENANCY", "dojot.tenancy")
+dojot_subject_tenancy = os.environ.get(
+    "DOJOT_SUBJECT_TENANCY", "dojot.tenancy")
 
 # Global subject to use when listening to device CRUD events
-dojot_subject_device = os.environ.get('DOJOT_SUBJECT_DEVICES', "dojot.device-manager.device")
+dojot_subject_device = os.environ.get(
+    'DOJOT_SUBJECT_DEVICES', "dojot.device-manager.device")
 
 # Global subject to use when listening to device data events
-dojot_subject_device_data = os.environ.get('DOJOT_SUBJECT_DEVICE_DATA', "device-data")
+dojot_subject_device_data = os.environ.get(
+    'DOJOT_SUBJECT_DEVICE_DATA', "device-data")
 
 # Global service to use when publishing dojot management events
 # such as new tenants
 dojot_service_management = os.environ.get("DOJOT_SERVICE_MANAGEMENT",
                                           "dojot-management")
+
+dojot_notification_on = os.environ.get("DOJOT_NOTIFICATION_ON", True)
 
 #
 # Other dojot services
@@ -48,4 +53,5 @@ data_broker_url = os.environ.get("DATA_BROKER_URL", "http://data-broker")
 # auth related configuration
 auth_url = os.environ.get('AUTH_URL', "http://auth:5000")
 # device-manager URL
-device_manager_url = os.environ.get('DEVICE_MANAGER_URL', "http://device-manager:5000")
+device_manager_url = os.environ.get(
+    'DEVICE_MANAGER_URL', "http://device-manager:5000")

--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -268,24 +268,35 @@ class LoggingInterface(object):
                 'Logging level must be DEBUG, INFO, WARNING, ERROR or CRITICAL!', 'level')
 
 
+def str2_bool(bool):
+    """
+     function that checks the type and value of the environment variable: DOJOT_PERSIST_NOTIFICATION_ONLY;
+     Because docker-compose.yml only 
+     accepts numeric and String values, this type checking prevents future errors 
+    """
+    return bool.lower() in ("yes", "true", "t", "1")
+
+
 def start_dojot_messenger(config, persister):
 
     messenger = Messenger("Persister", config)
     messenger.init()
     # Persister Only Notification
     messenger.create_channel("dojot.notifications", "r")
-    messenger.on(config.dojot['subjects']['tenancy'],"message", persister.handle_new_tenant)
-    messenger.on("dojot.notifications", "message",persister.handle_notification)
-    LOGGER.info('Only notifications are enabled')
+    messenger.on(config.dojot['subjects']['tenancy'],
+                 "message", persister.handle_new_tenant)
+    messenger.on("dojot.notifications", "message",
+                 persister.handle_notification)
 
-    if conf.dojot_persist_notifications_only != True:
+    if str2_bool(conf.dojot_persist_notifications_only) != True:
         LOGGER.info("Persisting device events")
         # TODO: add notifications to config on dojot-module-python
         messenger.create_channel(config.dojot['subjects']['devices'], "r")
         messenger.create_channel(config.dojot['subjects']['device_data'], "r")
-        messenger.on(config.dojot['subjects']['devices'],"message", persister.handle_event_devices)
-        messenger.on(config.dojot['subjects']['device_data'],"message", persister.handle_event_data)
-
+        messenger.on(config.dojot['subjects']['devices'],
+                     "message", persister.handle_event_devices)
+        messenger.on(config.dojot['subjects']['device_data'],
+                     "message", persister.handle_event_data)
 
 
 def main():

--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -270,9 +270,7 @@ class LoggingInterface(object):
 
 def str2_bool(v):
     """
-     function that checks the type and value of the environment variable: DOJOT_PERSIST_NOTIFICATION_ONLY;
-     Because docker-compose.yml only 
-     accepts numeric and String values, this type checking prevents future errors 
+     this function basically only converts a string to boolean
     """
     if type(v) is bool:
         return v
@@ -289,8 +287,10 @@ def start_dojot_messenger(config, persister):
                  "message", persister.handle_new_tenant)
     messenger.on("dojot.notifications", "message",
                  persister.handle_notification)
+    LOGGER.info('Listen to notification events')
 
     if str2_bool(conf.dojot_persist_notifications_only) != True:
+        LOGGER.info("Listen to devices events")
         # TODO: add notifications to config on dojot-module-python
         messenger.create_channel(config.dojot['subjects']['devices'], "r")
         messenger.create_channel(config.dojot['subjects']['device_data'], "r")

--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -270,8 +270,7 @@ class LoggingInterface(object):
 
 def str2_bool(v):
     """
-     If the value is Boolean, it just returns the value. In case the received value is not boolean, 
-     it is verified if the received value is a true value, being these possible values "yes", "true", "t", "1" ignoring case sensitive.
+     this function basically only converts a string to boolean
     """
     if type(v) is bool:
         return v
@@ -289,16 +288,17 @@ def start_dojot_messenger(config, persister, dojot_persist_notifications_only):
     messenger.on("dojot.notifications", "message",
                  persister.handle_notification)
     LOGGER.info('Listen to notification events')
-
+    LOGGER.info("Listen to tenancy events")
+    
     if str2_bool(dojot_persist_notifications_only) != True:
-        LOGGER.info("Listen to devices events")
-        # TODO: add notifications to config on dojot-module-python
+
         messenger.create_channel(config.dojot['subjects']['devices'], "r")
         messenger.create_channel(config.dojot['subjects']['device_data'], "r")
         messenger.on(config.dojot['subjects']['devices'],
                      "message", persister.handle_event_devices)
         messenger.on(config.dojot['subjects']['device_data'],
                      "message", persister.handle_event_data)
+        LOGGER.info("Listen to devices events")
 
 
 def main():

--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -270,7 +270,8 @@ class LoggingInterface(object):
 
 def str2_bool(v):
     """
-     this function basically only converts a string to boolean
+     If the value is Boolean, it just returns the value. In case the received value is not boolean, 
+     it is verified if the received value is a true value, being these possible values "yes", "true", "t", "1" ignoring case sensitive.
     """
     if type(v) is bool:
         return v
@@ -278,6 +279,7 @@ def str2_bool(v):
 
 
 def start_dojot_messenger(config, persister):
+
     messenger = Messenger("Persister", config)
     messenger.init()
     # Persister Only Notification
@@ -286,10 +288,10 @@ def start_dojot_messenger(config, persister):
                  "message", persister.handle_new_tenant)
     messenger.on("dojot.notifications", "message",
                  persister.handle_notification)
-    LOGGER.info('Listen to notification events')
+    LOGGER.info('Listen to notification events ')
 
     if str2_bool(conf.dojot_persist_notifications_only) != True:
-        LOGGER.info("Listen to devices events")
+        LOGGER.info("Listen to devices events ")
         # TODO: add notifications to config on dojot-module-python
         messenger.create_channel(config.dojot['subjects']['devices'], "r")
         messenger.create_channel(config.dojot['subjects']['device_data'], "r")

--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -268,33 +268,24 @@ class LoggingInterface(object):
                 'Logging level must be DEBUG, INFO, WARNING, ERROR or CRITICAL!', 'level')
 
 
-def handle_choose_service(config, persister, check):
+def start_dojot_messenger(config, persister):
 
     messenger = Messenger("Persister", config)
     messenger.init()
+    # Persister Only Notification
+    messenger.create_channel("dojot.notifications", "r")
+    messenger.on(config.dojot['subjects']['tenancy'],"message", persister.handle_new_tenant)
+    messenger.on("dojot.notifications", "message",persister.handle_notification)
+    LOGGER.info('Only notifications are enabled')
 
-    messenger.create_channel(config.dojot['subjects']['devices'], "r")
-    messenger.create_channel(config.dojot['subjects']['device_data'], "r")
-
-    if conf.dojot_notification_on != True:
-        LOGGER.info("all services")
-
+    if conf.dojot_persist_notifications_only != True:
+        LOGGER.info("Persisting device events")
         # TODO: add notifications to config on dojot-module-python
-        messenger.create_channel("dojot.notifications", "r")
-        messenger.on(config.dojot['subjects']['devices'],
-                     "message", persister.handle_event_devices)
-        messenger.on(config.dojot['subjects']['device_data'],
-                     "message", persister.handle_event_data)
-    else:
-        # Persister Only Notification
-        LOGGER.info(f"One Notification: {conf.dojot_notification_on}")
+        messenger.create_channel(config.dojot['subjects']['devices'], "r")
+        messenger.create_channel(config.dojot['subjects']['device_data'], "r")
+        messenger.on(config.dojot['subjects']['devices'],"message", persister.handle_event_devices)
+        messenger.on(config.dojot['subjects']['device_data'],"message", persister.handle_event_data)
 
-        messenger.on(config.dojot['subjects']['tenancy'],
-                     "message", persister.handle_new_tenant)
-        messenger.on("dojot.notifications", "message",
-                     persister.handle_notification)
-
-    LOGGER.debug("... dojot messenger was successfully initialized.")
 
 
 def main():
@@ -311,7 +302,8 @@ def main():
     LOGGER.debug("... persister was successfully initialized.")
     LOGGER.debug("Initializing dojot messenger...")
 
-    handle_choose_service(config, persister, conf.dojot_notification_on)
+    start_dojot_messenger(config, persister)
+    LOGGER.debug("... dojot messenger was successfully initialized.")
 
     # Create falcon app
     app = falcon.API()

--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -268,13 +268,15 @@ class LoggingInterface(object):
                 'Logging level must be DEBUG, INFO, WARNING, ERROR or CRITICAL!', 'level')
 
 
-def str2_bool(bool):
+def str2_bool(v):
     """
      function that checks the type and value of the environment variable: DOJOT_PERSIST_NOTIFICATION_ONLY;
      Because docker-compose.yml only 
      accepts numeric and String values, this type checking prevents future errors 
     """
-    return bool.lower() in ("yes", "true", "t", "1")
+    if type(v) is bool:
+        return v
+    return v.lower() in ("yes", "true", "t", "1")
 
 
 def start_dojot_messenger(config, persister):
@@ -289,7 +291,6 @@ def start_dojot_messenger(config, persister):
                  persister.handle_notification)
 
     if str2_bool(conf.dojot_persist_notifications_only) != True:
-        LOGGER.info("Persisting device events")
         # TODO: add notifications to config on dojot-module-python
         messenger.create_channel(config.dojot['subjects']['devices'], "r")
         messenger.create_channel(config.dojot['subjects']['device_data'], "r")

--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -278,7 +278,7 @@ def str2_bool(v):
     return v.lower() in ("yes", "true", "t", "1")
 
 
-def start_dojot_messenger(config, persister):
+def start_dojot_messenger(config, persister, dojot_persist_notifications_only):
 
     messenger = Messenger("Persister", config)
     messenger.init()
@@ -288,10 +288,10 @@ def start_dojot_messenger(config, persister):
                  "message", persister.handle_new_tenant)
     messenger.on("dojot.notifications", "message",
                  persister.handle_notification)
-    LOGGER.info('Listen to notification events ')
+    LOGGER.info('Listen to notification events')
 
-    if str2_bool(conf.dojot_persist_notifications_only) != True:
-        LOGGER.info("Listen to devices events ")
+    if str2_bool(dojot_persist_notifications_only) != True:
+        LOGGER.info("Listen to devices events")
         # TODO: add notifications to config on dojot-module-python
         messenger.create_channel(config.dojot['subjects']['devices'], "r")
         messenger.create_channel(config.dojot['subjects']['device_data'], "r")
@@ -315,7 +315,8 @@ def main():
     LOGGER.debug("... persister was successfully initialized.")
     LOGGER.debug("Initializing dojot messenger...")
 
-    start_dojot_messenger(config, persister)
+    start_dojot_messenger(
+        config, persister, conf.dojot_persist_notifications_only)
     LOGGER.debug("... dojot messenger was successfully initialized.")
 
     # Create falcon app

--- a/history/subscriber/persister.py
+++ b/history/subscriber/persister.py
@@ -278,7 +278,6 @@ def str2_bool(v):
 
 
 def start_dojot_messenger(config, persister):
-
     messenger = Messenger("Persister", config)
     messenger.init()
     # Persister Only Notification

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -255,15 +255,13 @@ def test_persist_only_notifications(mock_messenger, mock_config, mock_create_ind
             "device_data": "device-data"
         }
     }
-    """
-    test persist only boolean valued notifications
-    """
+
+    #test persist only boolean valued notifications
     conf.dojot_persist_notifications_only = True
     start_dojot_messenger(mock_config, p)
 
-    """
-    test persist only text valued notifications
-    """
+    
+    #test persist only text valued notifications
     conf.dojot_persist_notifications_only = 'True'
     start_dojot_messenger(mock_config, p)
 

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -217,15 +217,12 @@ def test_persist_all_events(mock_messenger, mock_config, mock_create_index):
             "device_data": "device-data"
         }
     }
-    """
-    test persist all boolean valued events
-    """
+    #test persist all boolean valued events
+
     conf.dojot_persist_notifications_only = False
     start_dojot_messenger(mock_config, p)
 
-    """
-    test persist all text valued events
-    """
+    #test persist all text valued events
     conf.dojot_persist_notifications_only = 'False'
     start_dojot_messenger(mock_config, p)
 

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -222,60 +222,35 @@ def test_persist_all_events(mock_on, mock_create_channel, mock_messenger, mock_c
 
     # test persist all boolean valued events
     start_dojot_messenger(mock_config, p, False)
+    mock_messenger.assert_called_once_with("Persister", mock_config)
 
-    mock_create_notifications = mock_create_channel("dojot.notifications", "r")
+    mock_messenger().create_channel.assert_any_call("dojot.notifications", "r")
 
-    mock_create_all_services_devices = mock_create_channel(
-        mock_config.dojot['subjects']['devices'], "r")
-
-    mock_create_all_services_device_data = mock_create_channel(
-        mock_config.dojot['subjects']['device_data'], "r")
-
-    mock_on_handle_new_tenent = mock_on(mock_config.dojot['subjects']['tenancy'],
+    mock_messenger().on.assert_any_call(mock_config.dojot['subjects']['tenancy'],
                                         "message", p.handle_new_tenant)
-    mock_on_handle_notification = mock_on(
-        "dojot.notifications", "message", p.handle_notification)
 
-    mock_on_handle_event_devices = mock_on(mock_config.dojot['subjects']['devices'],
-                                           "message", p.handle_event_devices)
+    mock_messenger().on.assert_any_call("dojot.notifications", "message",
+                                        p.handle_notification)
 
-    mock_on_handle_event_data = mock_on(mock_config.dojot['subjects']['device_data'],
-                                        "message", p.handle_event_data)
-
-    assert mock_create_indexes.called
-    assert mock_messenger.called
-
-    assert mock_create_notifications == mock_create_channel.assert_any_call(
-        "dojot.notifications", "r")
-
-    assert mock_create_all_services_devices == mock_create_channel.assert_any_call(
+    mock_messenger().create_channel.assert_any_call(
         mock_config.dojot['subjects']['devices'], "r")
 
-    assert mock_create_all_services_device_data == mock_create_channel.assert_any_call(
+    mock_messenger().create_channel.assert_any_call(
         mock_config.dojot['subjects']['device_data'], "r")
 
-    assert mock_on_handle_new_tenent == mock_on.assert_any_call(mock_config.dojot['subjects']['tenancy'],
-                                                                "message", p.handle_new_tenant)
-    assert mock_on_handle_notification == mock_on.assert_any_call(
-        "dojot.notifications", "message", p.handle_notification)
+    mock_messenger().on.assert_any_call(mock_config.dojot['subjects']['devices'],
+                                        "message", p.handle_event_devices)
 
-    assert mock_on_handle_event_devices == mock_on.assert_any_call(mock_config.dojot['subjects']['devices'],
-                                                                   "message", p.handle_event_devices)
-
-    assert mock_on_handle_event_data == mock_on.assert_any_call(mock_config.dojot['subjects']['device_data'],
-                                                                "message", p.handle_event_data)
-
-    assert mock_create_channel.call_count == 3
-
-    assert mock_on.call_count == 4
+    mock_messenger().on.assert_any_call(mock_config.dojot['subjects']['device_data'],
+                                        "message", p.handle_event_data)
 
 
 @patch.object(Persister, 'create_indexes')
 @patch.object(Config, 'load_defaults')
 @patch('history.subscriber.persister.Messenger')
-@patch.object(Messenger, 'create_channel', return_value=None)
-@patch.object(Messenger, 'on', return_value=None)
-def test_persist_only_notifications(mock_create_channel, mock_on, mock_messenger, mock_config, create_indexes):
+@patch.object(Messenger, 'create_channel')
+@patch.object(Messenger, 'on')
+def test_persist_only_notifications(mock_on, mock_create_channel, mock_messenger, mock_config, create_indexes):
 
     from history.subscriber.persister import start_dojot_messenger
     from history import conf
@@ -295,46 +270,31 @@ def test_persist_only_notifications(mock_create_channel, mock_on, mock_messenger
     }
     # test persist only boolean valued notifications
     start_dojot_messenger(mock_config, p, True)
-    mock_test_create_channel = mock_create_channel("dojot.notifications", "r")
+    mock_messenger.assert_called_once_with("Persister", mock_config)
 
-    mock_on_handle_new_tenent = mock_on(mock_config.dojot['subjects']['tenancy'],
+    mock_messenger().create_channel.assert_any_call("dojot.notifications", "r")
+    mock_messenger().on.assert_any_call(mock_config.dojot['subjects']['tenancy'],
                                         "message", p.handle_new_tenant)
 
-    mock_on_handle_notification = mock_on(
-        "dojot.notifications", "message", p.handle_notification)
-
-    assert create_indexes.called
-    assert mock_messenger.called
-    assert mock_test_create_channel == mock_create_channel.assert_called_once_with(
-        "dojot.notifications", "r")
-
-    assert mock_create_channel.call_count == 1
-
-    assert mock_on_handle_new_tenent == mock_on.assert_any_call(mock_config.dojot['subjects']['tenancy'],
-                                                                "message", p.handle_new_tenant)
-
-    assert mock_on_handle_notification == mock_on.assert_any_call(
-        "dojot.notifications", "message", p.handle_notification)
-
-    assert mock_on.call_count == 2
+    mock_messenger().on.assert_any_call("dojot.notifications", "message",
+                                        p.handle_notification)
 
 
 def test_str2_bool_return_true():
     from history.subscriber.persister import str2_bool
-
-    mock_return = str2_bool('true')
-    mock_value_expected = True
-
-    assert (mock_value_expected == mock_return)
+    assert True == str2_bool('true')
+    assert True == str2_bool('yes')
+    assert True == str2_bool('t')
+    assert True == str2_bool('1')
 
 
 def test_str2_bool_return_false():
     from history.subscriber.persister import str2_bool
 
-    mock_return = str2_bool('false')
-    mock_value_expected = False
-
-    assert (mock_value_expected == mock_return)
+    assert False == str2_bool('false')
+    assert False == str2_bool('no')
+    assert False == str2_bool('f')
+    assert False == str2_bool('0')
 
 
 @patch.object(Auth, 'get_tenants', return_value=None)

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -221,8 +221,7 @@ def test_persist_all_events(mock_on, mock_create_channel, mock_messenger, mock_c
     }
 
     # test persist all boolean valued events
-    conf.dojot_persist_notifications_only = False
-    start_dojot_messenger(mock_config, p)
+    start_dojot_messenger(mock_config, p, False)
 
     mock_create_notifications = mock_create_channel("dojot.notifications", "r")
 
@@ -295,8 +294,7 @@ def test_persist_only_notifications(mock_create_channel, mock_on, mock_messenger
         }
     }
     # test persist only boolean valued notifications
-    conf.dojot_persist_notifications_only = True
-    start_dojot_messenger(mock_config, p)
+    start_dojot_messenger(mock_config, p, True)
     mock_test_create_channel = mock_create_channel("dojot.notifications", "r")
 
     mock_on_handle_new_tenent = mock_on(mock_config.dojot['subjects']['tenancy'],
@@ -307,8 +305,11 @@ def test_persist_only_notifications(mock_create_channel, mock_on, mock_messenger
 
     assert create_indexes.called
     assert mock_messenger.called
-    assert mock_test_create_channel == mock_create_channel.assert_called_with(
+    assert mock_test_create_channel == mock_create_channel.assert_called_once_with(
         "dojot.notifications", "r")
+
+    assert mock_create_channel.call_count == 1
+
     assert mock_on_handle_new_tenent == mock_on.assert_any_call(mock_config.dojot['subjects']['tenancy'],
                                                                 "message", p.handle_new_tenant)
 

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -282,19 +282,19 @@ def test_persist_only_notifications(mock_on, mock_create_channel, mock_messenger
 
 def test_str2_bool_return_true():
     from history.subscriber.persister import str2_bool
-    assert True == str2_bool('true')
-    assert True == str2_bool('yes')
-    assert True == str2_bool('t')
-    assert True == str2_bool('1')
+    assert True is str2_bool('true')
+    assert True is str2_bool('yes')
+    assert True is str2_bool('t')
+    assert True is str2_bool('1')
 
 
 def test_str2_bool_return_false():
     from history.subscriber.persister import str2_bool
 
-    assert False == str2_bool('false')
-    assert False == str2_bool('no')
-    assert False == str2_bool('f')
-    assert False == str2_bool('0')
+    assert False is str2_bool('false')
+    assert False is str2_bool('no')
+    assert False is str2_bool('f')
+    assert False is str2_bool('0')
 
 
 @patch.object(Auth, 'get_tenants', return_value=None)

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -195,14 +195,10 @@ class TestLoggingInterface(unittest.TestCase):
         self.assertTrue('invalid_param' in str(context.exception))
 
 
-# @patch.object(Auth, 'get_tenants', return_value=None)
 @patch.object(Persister, 'create_indexes_for_notifications')
 @patch.object(Config, 'load_defaults')
 @patch('history.subscriber.persister.Messenger')
-# @patch.object(Persister, 'init_mongodb')
-# @patch('history.subscriber.persister.falcon.API')
-# @patch('history.subscriber.persister.simple_server')
-def test_handle_notification_false(mock_messenger, mock_config, mock_create_indexes_for_notifications):
+def test_persist_all_events(mock_messenger, mock_config, mock_create_index):
 
     from history.subscriber.persister import start_dojot_messenger
     from history import conf
@@ -221,19 +217,26 @@ def test_handle_notification_false(mock_messenger, mock_config, mock_create_inde
             "device_data": "device-data"
         }
     }
+    """
+    test persist all boolean valued events
+    """
     conf.dojot_persist_notifications_only = False
     start_dojot_messenger(mock_config, p)
 
+    """
+    test persist all text valued events
+    """
+    conf.dojot_persist_notifications_only = 'False'
+    start_dojot_messenger(mock_config, p)
+
     assert mock_messenger.called
-    assert mock_create_indexes_for_notifications.called
-
-
+    assert mock_create_index.called
 
 
 @patch.object(Persister, 'create_indexes_for_notifications')
 @patch.object(Config, 'load_defaults')
 @patch('history.subscriber.persister.Messenger')
-def test_handle_notification_true(mock_messenger, mock_config, mock_create_indexes_for_notifications):
+def test_persist_only_notifications(mock_messenger, mock_config, mock_create_indexes_for_notifications):
 
     from history.subscriber.persister import start_dojot_messenger
     from history import conf
@@ -252,7 +255,16 @@ def test_handle_notification_true(mock_messenger, mock_config, mock_create_index
             "device_data": "device-data"
         }
     }
+    """
+    test persist only boolean valued notifications
+    """
     conf.dojot_persist_notifications_only = True
+    start_dojot_messenger(mock_config, p)
+
+    """
+    test persist only text valued notifications
+    """
+    conf.dojot_persist_notifications_only = 'True'
     start_dojot_messenger(mock_config, p)
 
     assert mock_messenger.called
@@ -262,16 +274,16 @@ def test_handle_notification_true(mock_messenger, mock_config, mock_create_index
 @ patch.object(Auth, 'get_tenants', return_value=None)
 @ patch.object(Persister, 'init_mongodb')
 @ patch.object(Persister, 'create_indexes_for_notifications')
-@ patch('history.subscriber.persister.Messenger')
+@ patch('history.subscriber.persister.start_dojot_messenger')
 @ patch('history.subscriber.persister.falcon.API')
 @ patch('history.subscriber.persister.simple_server')
-def test_persister_main(mock_simple_server, mock_falcon_api, mock_messenger, mock_create_indexes_for_notifications,
+def test_persister_main(mock_simple_server, mock_falcon_api, mock_start_dojot_messenger, mock_create_indexes_for_notifications,
                         mock_init_mongodb, mock_get_tenants):
     from history.subscriber.persister import main
     main()
     assert mock_init_mongodb.called
     assert mock_get_tenants.called
     assert mock_create_indexes_for_notifications.called
-    assert mock_messenger.called
+    assert mock_start_dojot_messenger.called
     assert mock_falcon_api.called
     assert mock_simple_server.make_server.called

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -204,7 +204,7 @@ class TestLoggingInterface(unittest.TestCase):
 # @patch('history.subscriber.persister.simple_server')
 def test_handle_notification_false(mock_messenger, mock_config, mock_create_indexes_for_notifications):
 
-    from history.subscriber.persister import handle_choose_service
+    from history.subscriber.persister import start_dojot_messenger
     from history import conf
 
     p = Persister()
@@ -221,16 +221,13 @@ def test_handle_notification_false(mock_messenger, mock_config, mock_create_inde
             "device_data": "device-data"
         }
     }
-    conf.dojot_notification_on = False
-    handle_choose_service(mock_config, p, False)
-    # assert mock_init_mongodb.called
-    # assert mock_get_tenants.called
+    conf.dojot_persist_notifications_only = False
+    start_dojot_messenger(mock_config, p)
+
     assert mock_messenger.called
     assert mock_create_indexes_for_notifications.called
 
-    # assert mock_simple_server.make_server.called
-    # assert mock_falcon_api.called
-    # assert mock_simple_server.make_server.called
+
 
 
 @patch.object(Persister, 'create_indexes_for_notifications')
@@ -238,7 +235,7 @@ def test_handle_notification_false(mock_messenger, mock_config, mock_create_inde
 @patch('history.subscriber.persister.Messenger')
 def test_handle_notification_true(mock_messenger, mock_config, mock_create_indexes_for_notifications):
 
-    from history.subscriber.persister import handle_choose_service
+    from history.subscriber.persister import start_dojot_messenger
     from history import conf
 
     p = Persister()
@@ -255,8 +252,8 @@ def test_handle_notification_true(mock_messenger, mock_config, mock_create_index
             "device_data": "device-data"
         }
     }
-    conf.dojot_notification_on = True
-    handle_choose_service(mock_config, p, True)
+    conf.dojot_persist_notifications_only = True
+    start_dojot_messenger(mock_config, p)
 
     assert mock_messenger.called
     assert mock_create_indexes_for_notifications.called

--- a/tests/test_subscriber.py
+++ b/tests/test_subscriber.py
@@ -198,9 +198,7 @@ class TestLoggingInterface(unittest.TestCase):
 @patch.object(Persister, 'create_indexes')
 @patch.object(Config, 'load_defaults')
 @patch('history.subscriber.persister.Messenger')
-@patch.object(Messenger, 'create_channel', return_value=None)
-@patch.object(Messenger, 'on', return_value=None)
-def test_persist_all_events(mock_on, mock_create_channel, mock_messenger, mock_config, mock_create_indexes):
+def test_persist_all_events(mock_messenger, mock_config, mock_create_indexes):
 
     from history.subscriber.persister import start_dojot_messenger
     from history import conf
@@ -226,31 +224,23 @@ def test_persist_all_events(mock_on, mock_create_channel, mock_messenger, mock_c
 
     mock_messenger().create_channel.assert_any_call("dojot.notifications", "r")
 
-    mock_messenger().on.assert_any_call(mock_config.dojot['subjects']['tenancy'],
-                                        "message", p.handle_new_tenant)
+    mock_messenger().on.assert_any_call(mock_config.dojot['subjects']['tenancy'],"message", p.handle_new_tenant)
 
-    mock_messenger().on.assert_any_call("dojot.notifications", "message",
-                                        p.handle_notification)
+    mock_messenger().on.assert_any_call("dojot.notifications", "message",p.handle_notification)
 
-    mock_messenger().create_channel.assert_any_call(
-        mock_config.dojot['subjects']['devices'], "r")
+    mock_messenger().create_channel.assert_any_call(mock_config.dojot['subjects']['devices'], "r")
 
-    mock_messenger().create_channel.assert_any_call(
-        mock_config.dojot['subjects']['device_data'], "r")
+    mock_messenger().create_channel.assert_any_call(mock_config.dojot['subjects']['device_data'], "r")
 
-    mock_messenger().on.assert_any_call(mock_config.dojot['subjects']['devices'],
-                                        "message", p.handle_event_devices)
+    mock_messenger().on.assert_any_call(mock_config.dojot['subjects']['devices'],"message", p.handle_event_devices)
 
-    mock_messenger().on.assert_any_call(mock_config.dojot['subjects']['device_data'],
-                                        "message", p.handle_event_data)
+    mock_messenger().on.assert_any_call(mock_config.dojot['subjects']['device_data'],"message", p.handle_event_data)
 
 
 @patch.object(Persister, 'create_indexes')
 @patch.object(Config, 'load_defaults')
 @patch('history.subscriber.persister.Messenger')
-@patch.object(Messenger, 'create_channel')
-@patch.object(Messenger, 'on')
-def test_persist_only_notifications(mock_on, mock_create_channel, mock_messenger, mock_config, create_indexes):
+def test_persist_only_notifications(mock_messenger, mock_config, create_indexes):
 
     from history.subscriber.persister import start_dojot_messenger
     from history import conf
@@ -270,9 +260,11 @@ def test_persist_only_notifications(mock_on, mock_create_channel, mock_messenger
     }
     # test persist only boolean valued notifications
     start_dojot_messenger(mock_config, p, True)
+
     mock_messenger.assert_called_once_with("Persister", mock_config)
 
     mock_messenger().create_channel.assert_any_call("dojot.notifications", "r")
+
     mock_messenger().on.assert_any_call(mock_config.dojot['subjects']['tenancy'],
                                         "message", p.handle_new_tenant)
 
@@ -282,6 +274,7 @@ def test_persist_only_notifications(mock_on, mock_create_channel, mock_messenger
 
 def test_str2_bool_return_true():
     from history.subscriber.persister import str2_bool
+
     assert True is str2_bool('true')
     assert True is str2_bool('yes')
     assert True is str2_bool('t')


### PR DESCRIPTION
modification of the behavior of the persister service.
A flag has been added to change the behavior if it is "True", with that the service will only persist notifications, and when it is "False", the service will work normally.

* **Please check if the PR fulfills these requirements**
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)


* **Is there any issue related to this PR in other repository?** (such as dojot/dojot)


* **Other information**:
[dojot/dojot#2116](https://github.com/dojot/dojot/issues/2116)